### PR TITLE
Do not mention people with #nobot in their profile

### DIFF
--- a/fight.py
+++ b/fight.py
@@ -77,6 +77,9 @@ def get_user_name_avatar(mastodon, mastodon_name):
 
     account = mastodon.account(local_user_id)
 
+    if "#nobot" in account.note:
+      raise Exception # TODO
+
     return account["username"], account["acct"], account["avatar_static"]
 
 


### PR DESCRIPTION
People may not want to be bothered by bots.
Such people usually include “#nobot” in their profile.
This (crude) change prevents the bot from mentioning such people.